### PR TITLE
Dockerfile: add libncurses5-dev to deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN  \
 	libssl-dev \
 	device-tree-compiler \
 	u-boot-tools \
+	libncurses5-dev \
 	zip \
 	&& \
 	apt-get clean


### PR DESCRIPTION
Follow https://github.com/linuxboot/heads/pull/1510 to fix building openssl.